### PR TITLE
画像プロキシがおかしな画像をキャッシュ

### DIFF
--- a/web/ImageProxy/Image.php
+++ b/web/ImageProxy/Image.php
@@ -329,9 +329,8 @@ class ImageProxy_Image
       //拡大はしない
       if($raw_width < $this->_width || $raw_height < $this->_height)
       {
-        if($this->_is_debug) ImageProxy_Http::message('Illgal size specified. '.$this->_width.'/'.$this->_height);
-        //bodyをnullにすると強制的に404になります。
-        $this->_body = null;
+        //拡大しないため、元ファイルのままで、拡大後のパスにファイルをコピーする
+        file_put_contents($this->_save_path, $this->_body);
         return;
       }
 

--- a/web/ImageProxy/Image.php
+++ b/web/ImageProxy/Image.php
@@ -314,7 +314,7 @@ class ImageProxy_Image
     {
       ImageProxy_Http::mkdir(dirname($this->_org_save_path));
       file_put_contents($this->_org_save_path, $this->_body);
-      chmod($this->_org_save_path, 0777);
+      chmod($this->_org_save_path, 0666);
 
       if($this->_losslessCompress($this->_org_save_path))
       {
@@ -331,30 +331,32 @@ class ImageProxy_Image
       {
         //拡大しないため、元ファイルのままで、拡大後のパスにファイルをコピーする
         file_put_contents($this->_save_path, $this->_body);
-        return;
-      }
-
-      if(!$this->_width)
-      {
-        $this->_width = (int) ($raw_width * ($this->_height / $raw_height));
-      }
-      else if(!$this->_height)
-      {
-        $this->_height = (int) ($raw_height * ($raw_width / $this->_width));
-      }
-
-      if(preg_match('/\.gif$/u', $this->_save_path))
-      {
-        $command = 'convert %s -coalesce -resize %dx%d -deconstruct %s';
       }
       else
       {
-        $command = 'convert %s -resize %dx%d %s';
+        if(!$this->_width)
+        {
+          $this->_width = (int) ($raw_width * ($this->_height / $raw_height));
+        }
+        else if(!$this->_height)
+        {
+          $this->_height = (int) ($raw_height * ($raw_width / $this->_width));
+        }
+
+        if(preg_match('/\.gif$/u', $this->_save_path))
+        {
+          $command = 'convert %s -coalesce -resize %dx%d -deconstruct %s';
+        }
+        else
+        {
+          $command = 'convert %s -resize %dx%d %s';
+        }
+
+        exec(sprintf($command, $this->_org_save_path, $this->_width, $this->_height, $this->_save_path));
+        $need_reload = true;
       }
 
-      exec(sprintf($command, $this->_org_save_path, $this->_width, $this->_height, $this->_save_path));
-      chmod($this->_save_path, 0777);
-      $need_reload = true;
+      chmod($this->_save_path, 0666);
     }
 
     if($this->_losslessCompress($this->_save_path))

--- a/web/index.php
+++ b/web/index.php
@@ -1,8 +1,8 @@
 <?php
-require_once __DIR__ . '/ImageProxy/Image.php';
-require_once __DIR__ . '/ImageProxy/Http.php';
-require_once __DIR__ . '/ImageProxy/ExceptionHandler.php';
-require_once __DIR__ . '/ImageProxy/Image/Data.php';
+require_once dirname(__FILE__) . '/ImageProxy/Image.php';
+require_once dirname(__FILE__) . '/ImageProxy/Http.php';
+require_once dirname(__FILE__) . '/ImageProxy/ExceptionHandler.php';
+require_once dirname(__FILE__) . '/ImageProxy/Image/Data.php';
 
 set_exception_handler('ImageProxy_ExceptionHandler');
 


### PR DESCRIPTION
PHP5.1との互換性確保のための修正です。

masterへのPR
https://github.com/gomo/image-proxy/pull/4
